### PR TITLE
Remove confirmation prompt from isUVPAA

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1457,14 +1457,7 @@ This [=internal method=] accepts no arguments.
 
 [=[RPS]=] use this method to determine whether they can create a new credential using a [=user verification|user-verifying=] [=platform authenticator=].
 Upon invocation, the [=client=] employs a platform-specific procedure to discover available [=user verification|user-verifying=] [=platform authenticators=].
-If successful, the [=client=] then assesses whether the user is willing to create a credential using one of the available [=user verification|user-verifying=] [=platform authenticators=].
-This assessment may include various factors, such as:
-    - Whether the user is running in private or incognito mode.
-    - Whether the user has configured the [=client=] to not create such credentials.
-    - Whether the user has previously expressed an unwillingness to create a new credential for this [=[RP]=],
-        either through configuration or by declining a user interface prompt.
-    - The user's explicitly stated intentions, determined through user interaction.
-If this assessment is affirmative, the promise is resolved with the value of <i>True</i>.
+If any are discovered, the promise is resolved with the value of <i>True</i>.
 Otherwise, the promise is resolved with the value of <i>False</i>.
 Based on the result, the [=[RP]=] can take further actions to guide the user to create a credential.
 


### PR DESCRIPTION
As described in https://github.com/w3c/webauthn/issues/575#issuecomment-393134099

This aligns the spec with how @christiaanbrand and @akshayku assert (https://github.com/w3c/webauthn/issues/575#issuecomment-386059592, https://github.com/w3c/webauthn/issues/575#issuecomment-386650507) that Chrome and Edge behave.